### PR TITLE
Implement level progression rules

### DIFF
--- a/script.js
+++ b/script.js
@@ -152,16 +152,20 @@ const QuizBiblic = () => {
 
         if (esCorrecta) {
             setPuntuacio(prev => prev + nivell * 10);
-            setCorrectesConsecutives(prev => prev + 1);
-            
-            if (correctesConsecutives >= 1 && nivell < 5) {
-                setNivell(prev => prev + 1);
-                setCorrectesConsecutives(0);
-            }
+            setCorrectesConsecutives(prev => {
+                const nouCompte = prev + 1;
+                if (nouCompte >= 10) {
+                    if (nivell < 5) {
+                        setNivell(prevNivell => Math.min(prevNivell + 1, 5));
+                    }
+                    return 0;
+                }
+                return nouCompte;
+            });
         } else {
             setCorrectesConsecutives(0);
             if (nivell > 1) {
-                setNivell(prev => prev - 1);
+                setNivell(prev => Math.max(prev - 1, 1));
             }
         }
     };
@@ -286,7 +290,7 @@ const QuizBiblic = () => {
                             React.createElement('div', { className: 'hidden sm:block' }, React.createElement('br')),
                             React.createElement('div', {}, '👑 Corona de glòria amb joies precioses com l\'or, robí, maragda, safir i ametista!'),
                             React.createElement('div', { className: 'hidden sm:block' }, React.createElement('br')),
-                            React.createElement('div', {}, '🌟 Cada resposta correcta et fa pujar de nivell!'),
+                            React.createElement('div', {}, '🌟 Cada 10 respostes correctes et fan pujar de nivell!'),
                             React.createElement('div', { className: 'hidden sm:block' }, React.createElement('br')),
                             React.createElement('div', {}, '🎯 Quantes preguntes podràs respondre correctament?')
                         ),


### PR DESCRIPTION
## Summary
- advance a level only after 10 correct answers
- drop a level when a question is incorrect
- cap levels between 1 and 5
- clarify onboarding text about leveling up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68610fef06c48330b94e4bc833c8d270