### PR TITLE
Disable caching to show updates immediately

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,10 @@
     <meta name="viewport"
         content="width=device-width, initial-scale=1.0, user-scalable=yes, minimum-scale=1.0, maximum-scale=5.0">
     <title>Quiz Bíblic Súper Genial!</title>
-    <link rel="stylesheet" href="styles.css">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <link rel="stylesheet" href="styles.css" id="main-stylesheet">
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -30,7 +33,17 @@
 
 <body>
     <div id="root"></div>
-    <script type="text/babel" src="script.js"></script>
+    <script>
+        const ts = Date.now();
+        const style = document.getElementById('main-stylesheet');
+        if (style) {
+            style.href = `styles.css?t=${ts}`;
+        }
+        const script = document.createElement('script');
+        script.type = 'text/babel';
+        script.src = `script.js?t=${ts}`;
+        document.body.appendChild(script);
+    </script>
 </body>
 
 </html>

--- a/script.js
+++ b/script.js
@@ -82,7 +82,7 @@ const QuizBiblic = () => {
     useEffect(() => {
         const carregarPreguntes = async () => {
             try {
-                const response = await fetch('./preguntes.json');
+                const response = await fetch('./preguntes.json', { cache: 'no-store' });
                 const data = await response.json();
                 setPreguntes(data);
             } catch (error) {


### PR DESCRIPTION
## Summary
- prevent browser caching with `Cache-Control` meta tags
- load CSS and JS with a timestamp
- fetch quiz questions with `cache: 'no-store'`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686112ea384883309ef9c6831d2bfcfd